### PR TITLE
Fixed npm install error: files were missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,6 @@
   "scripts": {
     "postinstall": "node node/postinstall.js"
   },
-  "files": [
-    "node/postinstall.js",
-    "node/index.js"
-  ],
   "dependencies": {
     "chalk": "^0.4.0",
     "fs-extra": "^0.11.1",


### PR DESCRIPTION
Salut Sylvain,

Firstly I want to thank you for developing this project!

Last day I wanted to compile `node-janus` but I wasn't able to do that due to a compilation error. After having a look to the error, it seems that it was due to the installation of `janus-image-worker`:

```
✓ mozjpeg downloaded successfully
✓ jpeg turbo downloaded successfully
✓ jpeg-turbo built successfully.
✓ mozjpeg built successfully.

✗ Unable to build image recompressor.
/bin/sh: 1: ./configure: not found
```

Most of the files were missing due to the `files` key in `packages.json` file. It's a problem when we have to build the recompressor because we need all files needed to compile this project.
This is why I removed the `files` key.

Maybe there is a better solution but it seems this one will fix the problem :-)

Have a good day,

Matt
