### PR TITLE
Add missing repository information

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "scripts": {
     "postinstall": "node node/postinstall.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mozilla/janus-image-worker"
+  },
   "dependencies": {
     "chalk": "^0.4.0",
     "fs-extra": "^0.11.1",


### PR DESCRIPTION
Addresses warning message:

```
npm WARN package.json janus-image-worker@0.1.1 No repository field.
```